### PR TITLE
DGC-00: Add .polymer directory to fix Acquia deploy

### DIFF
--- a/.polymer/.gitignore
+++ b/.polymer/.gitignore
@@ -1,0 +1,4 @@
+# The .polymer directory is Polymer's project marker and files-root.
+# Polymer auto-generates config.yml here at runtime; keep it out of git
+# but track the directory itself so CI can locate the repo root.
+/config.yml


### PR DESCRIPTION
fixed the failing **Deploy to Acquia Dev** workflow.

## Root cause

The deploy step runs `vendor/bin/polymer artifact:deploy …` and was failing with:

```
PHP Fatal error: Uncaught Exception: Could not find .polymer directory in this or any parent directory.
```

`digitalpolygon/polymer` is pulled in as a moving dev branch (`0.x-dev`). The recent `composer.lock` re-resolution (commit `0d5da00`, the Drupal 11.3.11 security updates) advanced polymer from `1ee199c` to `0b3a81e`. That newer build locates the repo root by walking up the directory tree for a `.polymer/` directory, which this repo never had — so it fatals before any command runs.

Note: `polymer/polymer.yml` is still the user config and is unchanged; the new version needs `.polymer/` *in addition* to it.

## Fix

Add a tracked `.polymer/` directory at the repo root via `.polymer/.gitignore`. Committing the `.gitignore` keeps the directory in git/CI while ignoring the runtime-generated `config.yml`. Verified `vendor/bin/polymer list` now bootstraps cleanly instead of fatal-ing.

## Follow-up (not in this PR)

Polymer tracks the moving `0.x-dev` branch, so a future `composer update` could pull in another breaking convention change. Recommend pinning `digitalpolygon/polymer` to a stable tag.